### PR TITLE
serverless YDB: add location_id, sleep_after, serverless_database and timeouts 

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,18 +47,19 @@ No modules.
 | <a name="input_fixed_scale_size"></a> [fixed\_scale\_size](#input\_fixed\_scale\_size) | Number of instances for the Yandex Database cluster (only for dedicated) | `number` | `1` | no |
 | <a name="input_folder_id"></a> [folder\_id](#input\_folder\_id) | (Optional) The ID of the Yandex Cloud Folder that the resources belongs to.<br/><br/>    Allows to create bucket in different folder.<br/>    It will try to create bucket using IAM-token in provider config, not using access\_key.<br/>    If omitted, folder\_id specified in provider config and access\_key is used. | `string` | `null` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | A set of key/value label pairs to assign to the Yandex Database cluster | `map(string)` | `{}` | no |
-| <a name="input_location_id"></a> [location\_id](#input\_location\_id) | Location ID for the Yandex Database cluster (alternative to region block) | `string` | `null` | no |
+| <a name="input_location_id"></a> [location\_id](#input\_location\_id) | Location ID for the Yandex Database (e.g. ru-central1). For serverless, recommended for create/update. | `string` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the Yandex Database cluster | `string` | n/a | yes |
 | <a name="input_network_id"></a> [network\_id](#input\_network\_id) | ID of the network to attach the Yandex Database cluster to (only for dedicated) | `string` | `null` | no |
 | <a name="input_region_id"></a> [region\_id](#input\_region\_id) | Region ID for the Yandex Database cluster (only for dedicated) | `string` | `"ru-central1"` | no |
 | <a name="input_resource_preset_id"></a> [resource\_preset\_id](#input\_resource\_preset\_id) | The Yandex Database cluster preset (only for dedicated) | `string` | `null` | no |
 | <a name="input_scale_policy"></a> [scale\_policy](#input\_scale\_policy) | Scaling policy for the Yandex Database cluster. Can be either `fixed_scale` or `auto_scale` | `any` | `null` | no |
 | <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | A set of security group IDs to attach to the dedicated YDB cluster | `set(string)` | `[]` | no |
+| <a name="input_serverless_database"></a> [serverless\_database](#input\_serverless\_database) | Serverless database limits and throttling (only for database\_type = "serverless") | <pre>object({<br/>    throttling_rcu_limit        = optional(number)<br/>    storage_size_limit          = optional(number)<br/>    enable_throttling_rcu_limit = optional(bool)<br/>    provisioned_rcu_limit       = optional(number)<br/>  })</pre> | `null` | no |
 | <a name="input_sleep_after"></a> [sleep\_after](#input\_sleep\_after) | Delay after creation before proceeding with further operations | `number` | `null` | no |
 | <a name="input_storage_group_count"></a> [storage\_group\_count](#input\_storage\_group\_count) | Amount of storage groups of selected type for the Yandex Database cluster (only for dedicated) | `number` | `1` | no |
 | <a name="input_storage_type_id"></a> [storage\_type\_id](#input\_storage\_type\_id) | Storage type ID for the Yandex Database cluster (only for dedicated) | `string` | `"ssd"` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | Set of subnet IDs to attach the Yandex Database cluster to (only for dedicated) | `set(string)` | `null` | no |
-| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Timeout configuration for create, update, and delete operations | `string` | `null` | no |
+| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Default timeout for resource operations (e.g. "30m" for dedicated, "10m" for serverless) | `string` | `null` | no |
 
 ## Outputs
 

--- a/examples/serverless/main.tf
+++ b/examples/serverless/main.tf
@@ -1,35 +1,20 @@
-data "yandex_client_config" "client" {}
-
-module "network" {
-  source = "git::https://github.com/terraform-yacloud-modules/terraform-yandex-vpc.git?ref=v1.0.0"
-
-  folder_id = data.yandex_client_config.client.folder_id
-
-  blank_name = "ydb-vpc-nat-gateway"
-  labels = {
-    repo = "terraform-yacloud-modules/terraform-yandex-vpc"
-  }
-
-  azs = ["ru-central1-a", "ru-central1-b", "ru-central1-d"]
-
-  private_subnets = [["10.13.0.0/24"], ["10.14.0.0/24"], ["10.15.0.0/24"]]
-
-  create_vpc         = true
-  create_nat_gateway = true
-}
-
 module "ydb" {
   source = "../../"
 
-  # Тип базы данных: "dedicated" или "serverless"
   database_type = "serverless"
 
-  # Основные параметры
   name                = "ydb-serverless-example"
   deletion_protection = false
   description         = "Serverless YDB example instance"
+  location_id         = "ru-central1" # рекомендуется указывать для create/update
   labels = {
     environment = "production"
   }
 
+  serverless_database = {
+    throttling_rcu_limit        = 50
+    storage_size_limit          = 50
+    enable_throttling_rcu_limit = true
+    provisioned_rcu_limit       = 0
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -60,8 +60,27 @@ resource "yandex_ydb_database_dedicated" "dedicated_database" {
 resource "yandex_ydb_database_serverless" "serverless_database" {
   count               = var.database_type == "serverless" ? 1 : 0
   name                = var.name
+  folder_id           = local.folder_id
+  location_id         = var.location_id
   deletion_protection = var.deletion_protection
   description         = var.description
   labels              = var.labels
-  folder_id           = local.folder_id
+  sleep_after         = var.sleep_after
+
+  dynamic "serverless_database" {
+    for_each = var.serverless_database != null ? [var.serverless_database] : []
+    content {
+      throttling_rcu_limit        = serverless_database.value.throttling_rcu_limit
+      storage_size_limit          = serverless_database.value.storage_size_limit
+      enable_throttling_rcu_limit = serverless_database.value.enable_throttling_rcu_limit
+      provisioned_rcu_limit       = serverless_database.value.provisioned_rcu_limit
+    }
+  }
+
+  dynamic "timeouts" {
+    for_each = var.timeouts != null ? [var.timeouts] : []
+    content {
+      default = timeouts.value
+    }
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -69,7 +69,7 @@ variable "region_id" {
 }
 
 variable "location_id" {
-  description = "Location ID for the Yandex Database cluster (alternative to region block)"
+  description = "Location ID for the Yandex Database (e.g. ru-central1). For serverless, recommended for create/update."
   type        = string
   default     = null
 }
@@ -111,7 +111,20 @@ variable "scale_policy" {
 }
 
 variable "timeouts" {
-  description = "Timeout configuration for create, update, and delete operations"
+  description = "Default timeout for resource operations (e.g. \"30m\" for dedicated, \"10m\" for serverless)"
   type        = string
   default     = null
+}
+
+# --- Serverless-only ---
+
+variable "serverless_database" {
+  description = "Serverless database limits and throttling (only for database_type = \"serverless\")"
+  type = object({
+    throttling_rcu_limit        = optional(number)
+    storage_size_limit          = optional(number)
+    enable_throttling_rcu_limit = optional(bool)
+    provisioned_rcu_limit       = optional(number)
+  })
+  default = null
 }


### PR DESCRIPTION
Добавлены аргументы: location_id, sleep_after.
Добавлен динамический блок serverless_database с параметрами: throttling_rcu_limit, storage_size_limit, enable_throttling_rcu_limit, provisioned_rcu_limit.
Добавлен динамический блок timeouts для настройки таймаутов.
folder_id и location_id вынесены выше в блоке ресурса.